### PR TITLE
fixed typo in subscription.onUnsubscribe

### DIFF
--- a/multines.js
+++ b/multines.js
@@ -37,7 +37,7 @@ function register (server, options, next) {
     options = options || {}
 
     const wrapSubscribe = options.onSubscribe || ((socket, path, params, next) => next())
-    const wrapUnsubscribe = options.onUnubscribe || ((socket, path, params, next) => next())
+    const wrapUnsubscribe = options.onUnsubscribe || ((socket, path, params, next) => next())
 
     options.onSubscribe = (socket, path, params, next) => {
       const deliverMap = socket[kDeliver] || {}


### PR DESCRIPTION
Hi there! Thanks for building this out. I noticed that my onSubscribe hooks in my subscription declarations were no longer firing after adding in multines. Looks like there was a typo in your onUnsubscribe wrapper -- so this just fixes that typo. 

Thanks!