### PR TITLE
MQEmitter callback should never throw

### DIFF
--- a/multines.js
+++ b/multines.js
@@ -10,9 +10,9 @@ const kDeliver = Symbol.for('deliver')
 function buildDeliver (socket, topic) {
   return async function deliver (message, done) {
     if (topic === message.topic) {
-      await socket.publish('/' + topic, message.body)
+      await socket.publish('/' + topic, message.body).catch(() => {})
     } else {
-      await socket.publish('/' + topic, message)
+      await socket.publish('/' + topic, message).catch(() => {})
     }
   }
 }


### PR DESCRIPTION
According to the `MQEmitter` documentation, the [callback should never throw](https://github.com/mcollina/mqemitter#emitterontopic-callbackmessage-done-ondoneerr). However, the `nes` implementation of `socket.publish` can actually [throw errors](https://github.com/hapijs/nes/blob/d89819d2225291dd92f7fba550304c9af95505b4/lib/socket.js#L111) (for various reasons).

~When this happens `multines` completely crashes the server due to the unhandled promise rejection.~ Edit: The server crash was unrelated to this bug.

This pull-request explicitly handles (and ignores) the `socket.publish` rejections. This is not ideal (a better solution might involve changing the API to pass these errors downstream somehow), but at least it should no longer crash the server.